### PR TITLE
Add CI & deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main-mobile, main-mobile-dev ]
+  pull_request:
+    branches: [ main-mobile, main-mobile-dev ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,17 @@
+name: Deploy Dev
+
+on:
+  push:
+    branches: [ main-mobile-dev ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render deploy
+        run: |
+          curl -X POST \
+               -H "Authorization: Bearer ${{ secrets.RENDER_TOKEN }}" \
+               -H "Accept: application/json" \
+               -d '' \
+               https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID_DEV }}/deploys

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,25 @@
+name: Deploy (Staging & Prod)
+
+on:
+  push:
+    branches: [ main-mobile, prod ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - branch: main-mobile
+            service: ${{ secrets.RENDER_SERVICE_ID_STG }}
+          - branch: prod
+            service: ${{ secrets.RENDER_SERVICE_ID_PROD }}
+    if: github.ref_name == matrix.branch
+    steps:
+     - name: Trigger Render deploy
+        run: |
+          curl -X POST \
+               -H "Authorization: Bearer ${{ secrets.RENDER_TOKEN }}" \
+               -H "Accept: application/json" \
+               -d '' \
+               https://api.render.com/v1/services/${{ matrix.service }}/deploys

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,25 +1,25 @@
 name: Deploy (Staging & Prod)
-
 on:
   push:
-    branches: [ main-mobile, prod ]
-
+    branches: [main-mobile, prod]       # add main-mobile-dev if needed
 jobs:
   deploy:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - branch: main-mobile
-            service: ${{ secrets.RENDER_SERVICE_ID_STG }}
-          - branch: prod
-            service: ${{ secrets.RENDER_SERVICE_ID_PROD }}
-    if: github.ref_name == matrix.branch
+          - branch: main-mobile          # staging
+            service_secret: RENDER_SERVICE_ID_STG
+          - branch: prod                 # production
+            service_secret: RENDER_SERVICE_ID_PROD
+
     steps:
       - name: Trigger Render deploy
+        env:
+          SERVICE_ID: ${{ secrets[matrix.service_secret] }}
         run: |
           curl -X POST \
                -H "Authorization: Bearer ${{ secrets.RENDER_TOKEN }}" \
                -H "Accept: application/json" \
-        -d '' \
-               https://api.render.com/v1/services/${{ matrix.service }}/deploys
+               -d '{}' \
+               https://api.render.com/v1/services/${SERVICE_ID}/deploys

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,5 +21,5 @@ jobs:
           curl -X POST \
                -H "Authorization: Bearer ${{ secrets.RENDER_TOKEN }}" \
                -H "Accept: application/json" \
-              ' -d '' \
+        -d '' \
                https://api.render.com/v1/services/${{ matrix.service }}/deploys

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,10 +16,10 @@ jobs:
             service: ${{ secrets.RENDER_SERVICE_ID_PROD }}
     if: github.ref_name == matrix.branch
     steps:
-     - name: Trigger Render deploy
+      - name: Trigger Render deploy
         run: |
           curl -X POST \
                -H "Authorization: Bearer ${{ secrets.RENDER_TOKEN }}" \
                -H "Accept: application/json" \
-               -d '' \
+              ' -d '' \
                https://api.render.com/v1/services/${{ matrix.service }}/deploys


### PR DESCRIPTION
This pull request introduces GitHub Actions workflows for continuous integration and deployment.

- **ci.yml**: Runs `pnpm install` and `pnpm run build` on pushes and pull requests to `main-mobile` and `main-mobile-dev` branches.
- **deploy-dev.yml**: On pushes to the `main-mobile-dev` branch, triggers a deployment via Render using the `RENDER_SERVICE_ID_DEV` secret.
- **deploy-prod.yml**: Adds a matrix deployment workflow that deploys to staging when `main-mobile` is updated and to production when the `prod` branch updates.

These workflows will help automate builds and deployments across development, staging and production environments.